### PR TITLE
Fix bashrc brew binding issue for Linux compatibility

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -67,7 +67,10 @@ export PATH="$BUN_INSTALL/bin:$PATH"
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-eval "$(/opt/homebrew/bin/brew shellenv)" eval 
+# Only load brew if it's available
+if command -v brew &> /dev/null; then
+    eval "$(brew shellenv)"
+fi 
 
 export GOPATH=$HOME/go
 export PATH=$PATH:$GOPATH/bin


### PR DESCRIPTION
## Summary
• Added conditional check for brew command before evaluating shellenv
• Prevents errors on Linux systems where homebrew is not installed
• Maintains compatibility with macOS systems that have brew installed

## Test plan
- [ ] Test on Linux system without homebrew - bashrc should source without errors
- [ ] Test on macOS system with homebrew - brew functionality should work normally
- [ ] Verify no syntax errors in bashrc file

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)