### PR TITLE
fix: prevent bind warning when line editing is disabled

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -16,8 +16,8 @@ if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
 fi
 [[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
 
-# Configure readline settings (only in interactive shells)
-if [[ $- == *i* ]] && command -v bind &> /dev/null; then
+# Configure readline settings (only in interactive shells with line editing enabled)
+if [[ $- == *i* ]] && command -v bind &> /dev/null && (set -o | grep -q "emacs.*on\|vi.*on"); then
     # Ignore case during tab completion
     bind "set completion-ignore-case on"
 


### PR DESCRIPTION
Fixes #5

Adds additional check to ensure readline is enabled before using bind commands. This prevents the warning 'line editing not enabled' in contexts where bash is interactive but readline is disabled (e.g., CI environments).

Generated with [Claude Code](https://claude.ai/code)